### PR TITLE
Fix trade view keyboard issue

### DIFF
--- a/src/components/dex/Trade.vue
+++ b/src/components/dex/Trade.vue
@@ -558,6 +558,7 @@ export default {
     flex-direction: column;
     flex: 1;
     overflow: auto;
+    position: relative;
 
     .controls {
       flex: none;

--- a/src/components/dex/Trade.vue
+++ b/src/components/dex/Trade.vue
@@ -550,6 +550,7 @@ export default {
   display: flex;
   flex-direction: column;
   flex: 1;
+  height: 100%;
   overflow: hidden;
 
   > .body {


### PR DESCRIPTION
## Changes
* Added height: 100% to trade view.

THEORY: Not sure how to test if this works, outside of merging and shipping the code, but my theory is that it will based on the fact that the `Pair` view looks good when the keyboard comes up, and the only diff between `Pair` and `Trade` is `height:100%`.