### PR TITLE
Hide balances on Trade tab while input selected.

### DIFF
--- a/src/components/Input.vue
+++ b/src/components/Input.vue
@@ -37,6 +37,9 @@ export default {
     },
 
     onBlur() {
+      if (this.$listeners.blur) {
+        this.$listeners.blur();
+      }
       this.isFocused = false;
     },
 
@@ -45,6 +48,9 @@ export default {
     },
 
     onFocus() {
+      if (this.$listeners.focus) {
+        this.$listeners.focus();
+      }
       this.isFocused = true;
     },
 

--- a/src/components/dex/Trade.vue
+++ b/src/components/dex/Trade.vue
@@ -13,13 +13,13 @@
       </div>
       <div class="form">
         <div class="price" v-if="orderType === 'Limit'">
-          <aph-input v-model="$store.state.orderPrice"></aph-input>
+          <aph-input ref="inputPrice" v-model="$store.state.orderPrice" @focus="priceHasFocus=true" @blur="priceHasFocus=false"></aph-input>
           <div class="description">
             limit price ({{ baseHoldingSymbol }})
           </div>
         </div>
         <div class="quantity">
-          <aph-input v-model="$store.state.orderQuantity"></aph-input>
+          <aph-input ref="inputQuantity" v-model="$store.state.orderQuantity" @focus="quantityHasFocus=true" @blur="quantityHasFocus=false"></aph-input>
           <div class="description">
             amount ({{ quoteHoldingSymbol }})
           </div>
@@ -52,7 +52,7 @@
         </button>
       </div>
     </div>
-    <div class="footer">
+    <div v-if="shouldShowFooter" class="footer">
       <div :class="['balance', {active: quoteHolding.symbol === actionableHolding.symbol}]" :title="quoteBalanceToolTip">
         <div class="label">{{ quoteHolding.symbol }}</div>
         <button @click="showDepositWithdrawModal(quoteHolding)" :disabled="disableDepositWithdrawButton(quoteHolding.symbol)" class="deposit-withdraw-btn">{{ $t('depositWithdraw') }}</button>
@@ -235,6 +235,18 @@ export default {
       return !this.$store.state.orderQuantity || !this.$store.state.orderPrice || this.$isPending('placeOrder');
     },
 
+    shouldShowFooter() {
+      return !this.priceHasFocus && !this.quantityHasFocus;
+      /*
+      if (!this.$refs) {
+        return false;
+      }
+      console.log(this.$refs);
+      console.log(_.get(this.$refs, 'inputPrice'));
+      return !this.$refs.inputPrice;
+      */
+    },
+
     total() {
       if (!this.$store.state.orderQuantity) {
         return 0;
@@ -266,6 +278,8 @@ export default {
       postOnly: false,
       selectedPercent: null,
       side: 'Buy',
+      priceHasFocus: false,
+      quantityHasFocus: false,
     };
   },
 

--- a/src/components/dex/Trade.vue
+++ b/src/components/dex/Trade.vue
@@ -13,13 +13,13 @@
       </div>
       <div class="form">
         <div class="price" v-if="orderType === 'Limit'">
-          <aph-input ref="inputPrice" v-model="$store.state.orderPrice" @focus="priceHasFocus=true" @blur="priceHasFocus=false"></aph-input>
+          <aph-input v-model="$store.state.orderPrice" @focus="priceHasFocus=true" @blur="priceHasFocus=false"></aph-input>
           <div class="description">
             limit price ({{ baseHoldingSymbol }})
           </div>
         </div>
         <div class="quantity">
-          <aph-input ref="inputQuantity" v-model="$store.state.orderQuantity" @focus="quantityHasFocus=true" @blur="quantityHasFocus=false"></aph-input>
+          <aph-input v-model="$store.state.orderQuantity" @focus="quantityHasFocus=true" @blur="quantityHasFocus=false"></aph-input>
           <div class="description">
             amount ({{ quoteHoldingSymbol }})
           </div>
@@ -237,14 +237,6 @@ export default {
 
     shouldShowFooter() {
       return !this.priceHasFocus && !this.quantityHasFocus;
-      /*
-      if (!this.$refs) {
-        return false;
-      }
-      console.log(this.$refs);
-      console.log(_.get(this.$refs, 'inputPrice'));
-      return !this.$refs.inputPrice;
-      */
     },
 
     total() {


### PR DESCRIPTION
On Android the keyboard pushes the balances section of the Trade view up. This makes it impossible to see what you are typing on a small device without much vertical space. This hides the footer showing the holdings when the price or quantity inputs are in focus.

## Changes
* Hide balances on Trade tab while input selected.

## Screenshots

![tradeandroid_inputselected](https://user-images.githubusercontent.com/32698425/48524179-2e728280-e834-11e8-98cb-552049a00448.jpg)

![tradeandroid](https://user-images.githubusercontent.com/32698425/48524219-5366f580-e834-11e8-9fb6-f7946a67c811.jpg)

